### PR TITLE
actually set lzo as default & add tests

### DIFF
--- a/packages/app-builder-lib/src/options/SnapOptions.ts
+++ b/packages/app-builder-lib/src/options/SnapOptions.ts
@@ -127,7 +127,8 @@ export interface SnapOptions extends CommonLinuxOptions, TargetSpecificOptions {
   readonly title?: string | null
 
   /**
-   * Sets the compression type for the snap. Can be xz or lzo. Defaults to xz when not specified.
+   * Sets the compression type for the snap. Can be xz or lzo. Defaults to lzo when not specified.
+   * @default lzo
    */
    readonly compression?: "xz" | "lzo" | null
 }

--- a/packages/app-builder-lib/src/targets/snap.ts
+++ b/packages/app-builder-lib/src/targets/snap.ts
@@ -208,6 +208,10 @@ export default class SnapTarget extends Target {
       }
     }
 
+    if (snap.compression != null) {
+      args.push("--compression", snap.compression)
+    }
+
     if (packager.packagerOptions.effectiveOptionComputed != null && (await packager.packagerOptions.effectiveOptionComputed({ snap, desktopFile, args }))) {
       return
     }
@@ -223,9 +227,6 @@ export default class SnapTarget extends Target {
       args.push("--template-url", `electron4:${snapArch}`)
     }
 
-    if (options.compression != null) {
-      args.push("--compression", options.compression)
-    }
     await executeAppBuilder(args)
 
     await packager.info.callArtifactBuildCompleted({

--- a/packages/app-builder-lib/templates/snap/snapcraft.yaml
+++ b/packages/app-builder-lib/templates/snap/snapcraft.yaml
@@ -1,6 +1,7 @@
 base: core18
 grade: stable
 confinement: strict
+compression: lzo
 parts:
   launch-scripts:
     plugin: dump

--- a/test/src/linux/snapTest.ts
+++ b/test/src/linux/snapTest.ts
@@ -255,3 +255,44 @@ test.ifAll.ifDevOrLinuxCi(
     },
   })
 )
+
+test.ifDevOrLinuxCi(
+  "default compression",
+  app({
+    targets: snapTarget,
+    config: {
+      extraMetadata: {
+        name: "sep",
+      },
+      productName: "Sep",
+    },
+    effectiveOptionComputed: async ({ snap, args }) => {
+      expect(snap).toMatchSnapshot()
+      expect(snap.compression).toEqual("lzo")
+      expect(args).toEqual(expect.arrayContaining(["--compression", "lzo"]))
+      return true
+    },
+  })
+)
+
+test.ifDevOrLinuxCi(
+  "compression option",
+  app({
+    targets: snapTarget,
+    config: {
+      extraMetadata: {
+        name: "sep",
+      },
+      productName: "Sep",
+      snap: {
+        compression: "xz"
+      }
+    },
+    effectiveOptionComputed: async ({ snap, args }) => {
+      expect(snap).toMatchSnapshot()
+      expect(snap.compression).toEqual("xz")
+      expect(args).toEqual(expect.arrayContaining(["--compression", "xz"]))
+      return true
+    },
+  })
+)


### PR DESCRIPTION
Actually default to lzo by including it in the snapcraft template.
Also construct the builder argument from the descriptor & not from the option. We would ignore the compression option from the default template otherwise.

Also included: two rather superficial tests. I think the jest snapshots need to be updated, still.